### PR TITLE
Tag Commits in CI/CD

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  tag-main-with-semver:
+  tag-pull-requests-and-merges-to-main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
         run: |
           git tag -l
 
-      - name: Tag main with semver
+      - name: Tag
         run: |
           git tag -a ${GITHUB_REF##*/}-${GITHUB_SHA::8} -m "Tagging ${GITHUB_REF##*/} in CI/CD."
 


### PR DESCRIPTION
### Tag Commits in CI/CD 

Tagging on any pr or merge with a unique id such that we can reference this package as a dependency in the parser. 

Below is an image of a tag produced via the github action. 

<img width="1231" alt="image" src="https://github.com/climatepolicyradar/azure-pdf-parser/assets/58440325/7bea64d2-0185-42c9-a6cc-5329612453df">
