### PR TITLE
Convert Pdf Dimensions 

### DIFF
--- a/src/azure_pdf_parser/base.py
+++ b/src/azure_pdf_parser/base.py
@@ -1,6 +1,8 @@
 from azure.ai.formrecognizer import AnalyzeResult
 from pydantic import BaseModel
 
+DIMENSION_CONVERSION_FACTOR = 72
+
 
 class PDFPage(BaseModel):
     """Pdf document page object with content and page number."""

--- a/src/azure_pdf_parser/convert.py
+++ b/src/azure_pdf_parser/convert.py
@@ -191,8 +191,7 @@ def azure_api_response_to_parser_output(
             ),
         )
         for page in api_response.pages
-        if page is not None
-        and page.width is not None
+        if page.width is not None
         and page.height is not None
         and page.page_number is not None
     ]

--- a/src/azure_pdf_parser/convert.py
+++ b/src/azure_pdf_parser/convert.py
@@ -169,31 +169,36 @@ def extract_azure_api_response_page_metadata(
     Dimensions: Azure units are in inches but our corpus is in 72ppi pixels, and thus we
     multiply by a conversion factor.
     """
-    return [
-        PDFPageMetadata(
-            page_number=page.page_number - 1,
-            dimensions=(
-                page.width * DIMENSION_CONVERSION_FACTOR,
-                page.height * DIMENSION_CONVERSION_FACTOR,
-            ),
-        )
+    pdf_page_metadata = []
+    for page in api_response.pages:
         if (
             page.width is not None
             and page.height is not None
             and page.page_number is not None
-        )
-        else logger.warning(
-            f"Page metadata for page {page.page_number} is missing dimensions.",
-            extra={
-                "props": {
-                    "page_number": page.page_number,
-                    "width": page.width,
-                    "height": page.height,
-                }
-            },
-        )
-        for page in api_response.pages
-    ]
+        ):
+            pdf_page_metadata.append(
+                PDFPageMetadata(
+                    page_number=page.page_number - 1,
+                    dimensions=(
+                        page.width * DIMENSION_CONVERSION_FACTOR,
+                        page.height * DIMENSION_CONVERSION_FACTOR,
+                    ),
+                )
+            )
+
+        else:
+            logger.warning(
+                f"Page metadata for page {page.page_number} is missing dimensions.",
+                extra={
+                    "props": {
+                        "page_number": page.page_number,
+                        "width": page.width,
+                        "height": page.height,
+                    }
+                },
+            )
+
+    return pdf_page_metadata
 
 
 def azure_api_response_to_parser_output(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -8,6 +8,7 @@ from azure.ai.formrecognizer import (
 )
 from cpr_data_access.parser_models import PDFTextBlock, ParserInput, ParserOutput
 
+from azure_pdf_parser.base import DIMENSION_CONVERSION_FACTOR
 from azure_pdf_parser.experimental_base import (
     ExperimentalPDFTableBlock,
     ExperimentalParserOutput,
@@ -70,9 +71,12 @@ def test_azure_paragraph_to_text_block(document_paragraph: DocumentParagraph) ->
     assert text_block.text_block_id == "1"
     assert document_paragraph.bounding_regions is not None
     assert text_block.page_number == document_paragraph.bounding_regions[0].page_number
-    assert text_block.coords == polygon_to_co_ordinates(
-        document_paragraph.bounding_regions[0].polygon
-    )
+    assert text_block.coords == [
+        (DIMENSION_CONVERSION_FACTOR * coord[0], DIMENSION_CONVERSION_FACTOR * coord[1])
+        for coord in polygon_to_co_ordinates(
+            document_paragraph.bounding_regions[0].polygon
+        )
+    ]
     assert text_block.text == [document_paragraph.content]
     assert text_block.language is None
 


### PR DESCRIPTION
### Convert Pdf Dimensions 

The bounding box detection system used by Azure declares units in inches but our corpus uses 72ppi pixels.

Thus to maintain consistency the conversion step from an azure api response to a ParserOutput object is updated to facilitate this conversion. 

