### PR TITLE
feat: speed up GA setup by caching dependencies

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,16 +14,24 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Install poetry
+        run: pipx install poetry==1.3.2
+
+      - name: Install python or load from cache with dependencies
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: '3.9'
+          cache: 'poetry'
 
       - name: Install dependencies
         run: |
-          python -m pip install "poetry==1.3.2" && poetry install && poetry run pre-commit install
+          poetry install
+
+      - name: Install dependencies
+        run: |
+          poetry install && poetry run pre-commit install
 
       - name: Run pre-commit checks
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install python or load from cache with dependencies
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'poetry'
+          python-version: "3.9"
+          cache: "poetry"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install python or load from cache with dependencies
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'poetry'
+          python-version: "3.9"
+          cache: "poetry"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,16 +14,21 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Install poetry
+        run: pipx install poetry==1.2.2
+
+      - name: Install python or load from cache with dependencies
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: '3.9'
+          cache: 'poetry'
 
       - name: Install dependencies
         run: |
-          python -m pip install "poetry==1.2.2" && poetry install
+          poetry install
+
       - name: Run test suite
         run: |
           poetry run python -m pytest \


### PR DESCRIPTION
The setup-python action can cache the dependencies (once a build has successfully run on main). The dependency step in this repo is typically taking a little over a minute, and is around 90% of the total action time taken. Meaning we can save GA credits and our attention span