### PR TITLE
make parser importable and installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ To run the CLI with source urls on multiple documents use the following method:
 poetry run python -m src.cli --output-dir output --source_url cclw.executive.1.1 https://source.pdf --source_url cclw.executive.2.2 https://source.pdf
 ```
 
+The CLI can also be run programmatically, which is a shortcut for the below.
+
+``` python
+from azure_pdf_parser.run import run_parser
+
+# Saves JSONs named by IDs to output_dir
+run_parser(
+    output_dir=Path("./data/"),
+    ids_and_source_urls=_ids_and_urls, # (id, url) tuples
+)
+```
+
 ### Programmatically
 
 Install dependencies and enter the python shell: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["CPR-tech-team <tech@climatepolicyradar.org>"]
 packages = [{include = "azure_pdf_parser", from = "src"}]
 
 [tool.poetry.dependencies]
-python = "~3.9"
+python = ">=3.9,<4.0"
 azure-ai-formrecognizer = "^3.2.1"
 cpr-data-access = {git = "https://github.com/climatepolicyradar/data-access.git", tag = "v0.1.9"}
 requests = "^2.31.0"

--- a/src/azure_pdf_parser/run.py
+++ b/src/azure_pdf_parser/run.py
@@ -1,0 +1,158 @@
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Union, Callable, Optional, Iterable
+
+from azure.ai.formrecognizer import AnalyzeResult
+from azure.core.exceptions import HttpResponseError
+from cpr_data_access.parser_models import BackendDocument, ParserInput
+from dotenv import load_dotenv, find_dotenv
+from tqdm.auto import tqdm
+
+from azure_pdf_parser import AzureApiWrapper
+from azure_pdf_parser.convert import azure_api_response_to_parser_output
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+AZURE_PROCESSOR_KEY = os.environ.get("AZURE_PROCESSOR_KEY")
+AZURE_PROCESSOR_ENDPOINT = os.environ.get("AZURE_PROCESSOR_ENDPOINT")
+
+
+def process_document(
+    document_parameter: Union[str, bytes, None],
+    process_callable: Callable,
+    process_callable_retry: Callable,
+) -> Union[AnalyzeResult, None]:
+    """Attempt to retrieve an analyze result for a document."""
+    try:
+        return process_callable(document_parameter)
+    except HttpResponseError:
+        try:
+            return process_callable_retry(document_parameter)[1]
+        except Exception:
+            return None
+
+
+def convert_and_save_api_response(
+    import_id: str,
+    api_response: AnalyzeResult,
+    output_dir: Path,
+    source_url: Optional[str] = None,
+    extract_tables: bool = False,
+) -> None:
+    """Convert Azure API response to parser output and save to disk."""
+
+    backend_document = BackendDocument(
+        name="",
+        description="",
+        import_id=import_id,
+        family_import_id="",
+        family_slug="",
+        slug="",
+        publication_ts=datetime(1900, 1, 1),
+        source_url=source_url,
+        download_url=None,
+        type="",
+        source="",
+        category="",
+        geography="",
+        languages=[],
+        metadata={},
+    )
+
+    parser_input = ParserInput(
+        document_id=import_id,
+        document_name="",
+        document_description="",
+        document_source_url=source_url,
+        document_cdn_object="",
+        document_content_type="application/pdf",
+        document_md5_sum="",
+        document_slug="",
+        document_metadata=backend_document,
+    )
+
+    parser_output = azure_api_response_to_parser_output(
+        parser_input=parser_input,
+        md5_sum="",
+        api_response=api_response,
+        experimental_extract_tables=extract_tables,
+    )
+
+    (output_dir / f"{import_id}.json").write_text(parser_output.json())
+
+    LOGGER.info(f"Successfully processed and saved {import_id}.")
+
+
+def run_parser(
+    output_dir: Path,
+    ids_and_source_urls: Optional[Iterable[tuple[str, str]]] = None,
+    pdf_dir: Optional[Path] = None,
+    experimental_extract_tables: bool = False,
+) -> None:
+    """
+    Run Azure PDF parser on a directory of PDFs, or sequence of IDs and source URLs.
+
+    Outputs 'blank' parser output jsons to `--output-dir`, with just document ID,
+    document name, text block and page metadata information populated.
+
+    :param output_dir: directory to write output JSONs to
+    :param ids_and_source_urls: optional iterable of [(document ID, source URL), ...].
+    :param pdf_dir: optional directory of PDFs to parse. Filenames will be used as IDs.
+    :param extract_tables: optionally extract structured representations of tables.
+    :raises ValueError: if neither source_url or pdf_dir are provided, or if Azure
+    API keys are missing from environment variables.
+    """
+    load_dotenv(find_dotenv())
+
+    if not output_dir.exists():
+        LOGGER.warning(f"Output directory {output_dir} does not exist. Creating.")
+        output_dir.mkdir(parents=True)
+
+    if not AZURE_PROCESSOR_KEY or not AZURE_PROCESSOR_ENDPOINT:
+        raise ValueError(
+            """Missing Azure API credentials. Set AZURE_PROCESSOR_KEY and 
+            AZURE_PROCESSOR_ENDPOINT environment variables."""
+        )
+
+    if not ids_and_source_urls and not pdf_dir:
+        raise ValueError("""Must provide either source urls or pdf directory.""")
+
+    azure_client = AzureApiWrapper(AZURE_PROCESSOR_KEY, AZURE_PROCESSOR_ENDPOINT)
+
+    if ids_and_source_urls:
+        for import_id, url in ids_and_source_urls:
+            analyse_result = process_document(
+                document_parameter=url,
+                process_callable=azure_client.analyze_document_from_url,
+                process_callable_retry=azure_client.analyze_large_document_from_url,
+            )
+
+            if analyse_result:
+                convert_and_save_api_response(
+                    import_id=import_id,
+                    source_url=url,
+                    api_response=analyse_result,
+                    output_dir=output_dir,
+                    extract_tables=experimental_extract_tables,
+                )
+    if pdf_dir:
+        for pdf_path in tqdm(list(pdf_dir.glob("*.pdf"))):
+            pdf_bytes = pdf_path.read_bytes()
+
+            analyse_result = process_document(
+                document_parameter=pdf_bytes,
+                process_callable=azure_client.analyze_document_from_bytes,
+                process_callable_retry=azure_client.analyze_large_document_from_bytes,
+            )
+
+            if analyse_result:
+                # Source url cannot be None and must have a minimum length.
+                convert_and_save_api_response(
+                    import_id=pdf_path.stem,
+                    api_response=analyse_result,
+                    output_dir=output_dir,
+                    extract_tables=experimental_extract_tables,
+                )

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,162 +1,17 @@
 import logging
 import os
-from datetime import datetime
 from pathlib import Path
-from typing import Union, Callable, Optional, Iterable
+from typing import Optional, Iterable
 
 import click
-from azure.ai.formrecognizer import AnalyzeResult
-from azure.core.exceptions import HttpResponseError
-from cpr_data_access.parser_models import BackendDocument, ParserInput
-from dotenv import load_dotenv, find_dotenv
-from tqdm.auto import tqdm
 
-from src.azure_pdf_parser import AzureApiWrapper
-from src.azure_pdf_parser.convert import azure_api_response_to_parser_output
+from azure_pdf_parser.run import run_parser
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
 AZURE_PROCESSOR_KEY = os.environ.get("AZURE_PROCESSOR_KEY")
 AZURE_PROCESSOR_ENDPOINT = os.environ.get("AZURE_PROCESSOR_ENDPOINT")
-
-
-def process_document(
-    document_parameter: Union[str, bytes, None],
-    process_callable: Callable,
-    process_callable_retry: Callable,
-) -> Union[AnalyzeResult, None]:
-    """Attempt to retrieve an analyze result for a document."""
-    try:
-        return process_callable(document_parameter)
-    except HttpResponseError:
-        try:
-            return process_callable_retry(document_parameter)[1]
-        except Exception:
-            return None
-
-
-def convert_and_save_api_response(
-    import_id: str,
-    api_response: AnalyzeResult,
-    output_dir: Path,
-    source_url: Optional[str] = None,
-    extract_tables: bool = False,
-) -> None:
-    """Convert Azure API response to parser output and save to disk."""
-
-    backend_document = BackendDocument(
-        name="",
-        description="",
-        import_id=import_id,
-        family_import_id="",
-        family_slug="",
-        slug="",
-        publication_ts=datetime(1900, 1, 1),
-        source_url=source_url,
-        download_url=None,
-        type="",
-        source="",
-        category="",
-        geography="",
-        languages=[],
-        metadata={},
-    )
-
-    parser_input = ParserInput(
-        document_id=import_id,
-        document_name="",
-        document_description="",
-        document_source_url=source_url,
-        document_cdn_object="",
-        document_content_type="application/pdf",
-        document_md5_sum="",
-        document_slug="",
-        document_metadata=backend_document,
-    )
-
-    parser_output = azure_api_response_to_parser_output(
-        parser_input=parser_input,
-        md5_sum="",
-        api_response=api_response,
-        experimental_extract_tables=extract_tables,
-    )
-
-    (output_dir / f"{import_id}.json").write_text(parser_output.json())
-
-    LOGGER.info(f"Successfully processed and saved {import_id}.")
-
-
-def run_parser(
-    output_dir: Path,
-    ids_and_source_urls: Optional[Iterable[tuple[str, str]]] = None,
-    pdf_dir: Optional[Path] = None,
-    experimental_extract_tables: bool = False,
-) -> None:
-    """
-    Run Azure PDF parser on a directory of PDFs, or sequence of IDs and source URLs.
-
-    Outputs 'blank' parser output jsons to `--output-dir`, with just document ID,
-    document name, text block and page metadata information populated.
-
-    :param output_dir: directory to write output JSONs to
-    :param ids_and_source_urls: optional iterable of [(document ID, source URL), ...].
-    :param pdf_dir: optional directory of PDFs to parse. Filenames will be used as IDs.
-    :param extract_tables: optionally extract structured representations of tables.
-    :raises ValueError: if neither source_url or pdf_dir are provided, or if Azure
-    API keys are missing from environment variables.
-    """
-    load_dotenv(find_dotenv())
-
-    if not output_dir.exists():
-        LOGGER.warning(f"Output directory {output_dir} does not exist. Creating.")
-        output_dir.mkdir(parents=True)
-
-    if not AZURE_PROCESSOR_KEY or not AZURE_PROCESSOR_ENDPOINT:
-        raise ValueError(
-            """Missing Azure API credentials. Set AZURE_PROCESSOR_KEY and 
-            AZURE_PROCESSOR_ENDPOINT environment variables."""
-        )
-
-    if not ids_and_source_urls and not pdf_dir:
-        raise ValueError("""Must provide either source urls or pdf directory.""")
-
-    azure_client = AzureApiWrapper(AZURE_PROCESSOR_KEY, AZURE_PROCESSOR_ENDPOINT)
-
-    if ids_and_source_urls:
-        for import_id, url in ids_and_source_urls:
-            analyse_result = process_document(
-                document_parameter=url,
-                process_callable=azure_client.analyze_document_from_url,
-                process_callable_retry=azure_client.analyze_large_document_from_url,
-            )
-
-            if analyse_result:
-                convert_and_save_api_response(
-                    import_id=import_id,
-                    source_url=url,
-                    api_response=analyse_result,
-                    output_dir=output_dir,
-                    extract_tables=experimental_extract_tables,
-                )
-    if pdf_dir:
-        for pdf_path in tqdm(list(pdf_dir.glob("*.pdf"))):
-            pdf_bytes = pdf_path.read_bytes()
-
-            analyse_result = process_document(
-                document_parameter=pdf_bytes,
-                process_callable=azure_client.analyze_document_from_bytes,
-                process_callable_retry=azure_client.analyze_large_document_from_bytes,
-            )
-
-            if analyse_result:
-                # Source url cannot be None and must have a minimum length.
-                convert_and_save_api_response(
-                    import_id=pdf_path.stem,
-                    api_response=analyse_result,
-                    output_dir=output_dir,
-                    extract_tables=experimental_extract_tables,
-                )
 
 
 @click.command()

--- a/src/cli.py
+++ b/src/cli.py
@@ -2,7 +2,7 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Union, Callable, Optional
+from typing import Union, Callable, Optional, Iterable
 
 import click
 from azure.ai.formrecognizer import AnalyzeResult
@@ -87,36 +87,11 @@ def convert_and_save_api_response(
     LOGGER.info(f"Successfully processed and saved {import_id}.")
 
 
-@click.command()
-@click.option(
-    "--source-url",
-    help="Source url with the associated document id to process.",
-    required=False,
-    multiple=True,
-    type=click.Tuple([str, str]),
-)
-@click.option(
-    "--pdf-dir",
-    help="Path to dir containing pdfs to process with document id's as filenames.",
-    required=False,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-)
-@click.option(
-    "--output-dir",
-    help="""Path to directory to write output JSONs to. Filenames and document IDs are 
-    be the filenames of the PDFs without extensions. Directory will be created if it 
-    doesn't exist.""",
-    required=True,
-    type=click.Path(file_okay=False, path_type=Path),
-)
-@click.option(
-    "--extract-tables",
-    help="Whether to extract tables from the PDFs.",
-    is_flag=True,
-    default=False,
-)
-def cli(
-    source_url: tuple[str, str], pdf_dir: Path, output_dir: Path, extract_tables: bool
+def run_parser(
+    output_dir: Path,
+    source_url: Optional[Iterable[tuple[str, str]]] = None,
+    pdf_dir: Optional[Path] = None,
+    extract_tables: bool = False,
 ) -> None:
     """
     Run Azure PDF parser on a directory of PDFs.
@@ -175,6 +150,43 @@ def cli(
                     output_dir=output_dir,
                     extract_tables=extract_tables,
                 )
+
+
+@click.command()
+@click.option(
+    "--source-url",
+    help="Source url with the associated document id to process.",
+    required=False,
+    multiple=True,
+    type=click.Tuple([str, str]),
+)
+@click.option(
+    "--pdf-dir",
+    help="Path to dir containing pdfs to process with document id's as filenames.",
+    required=False,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option(
+    "--output-dir",
+    help="""Path to directory to write output JSONs to. Filenames and document IDs are 
+    be the filenames of the PDFs without extensions. Directory will be created if it 
+    doesn't exist.""",
+    required=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+@click.option(
+    "--extract-tables",
+    help="Whether to extract tables from the PDFs.",
+    is_flag=True,
+    default=False,
+)
+def cli(
+    source_url: Optional[Iterable[tuple[str, str]]],
+    pdf_dir: Optional[Path],
+    output_dir: Path,
+    extract_tables: bool,
+) -> None:
+    return run_parser(output_dir, source_url, pdf_dir, extract_tables)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,3 +87,30 @@ def test_cli_with_source_urls(
         for file in output_dir_files:
             parser_output = ParserOutput.parse_obj(json.loads(file.read_text()))
             assert parser_output.document_id == file.stem
+
+
+def test_cli_importable(mock_azure_client, monkeypatch):
+    from src.cli import run_parser
+
+    monkeypatch.setenv("AZURE_PROCESSOR_KEY", "hello")
+    monkeypatch.setenv("AZURE_PROCESSOR_ENDPOINT", "https://example.com/")
+
+    with TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir) / "output"
+        source_urls = ["https://example.com/", "https://example.com/"]
+        import_ids = ["CCLW.executive.1.1", "CCLW.executive.1.2"]
+
+        # patch the azure client with mock
+        with patch("src.cli.AzureApiWrapper", return_value=mock_azure_client):
+            run_parser(
+                output_dir=output_dir,
+                source_url=zip(import_ids, source_urls),
+            )
+
+        assert (output_dir / "CCLW.executive.1.1.json").exists()
+        assert (output_dir / "CCLW.executive.1.2.json").exists()
+        output_dir_files = output_dir.glob("*.json")
+        assert len(list(output_dir_files)) == 2
+        for file in output_dir_files:
+            parser_output = ParserOutput.parse_obj(json.loads(file.read_text()))
+            assert parser_output.document_id == file.stem

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,7 +104,7 @@ def test_cli_importable(mock_azure_client, monkeypatch):
         with patch("src.cli.AzureApiWrapper", return_value=mock_azure_client):
             run_parser(
                 output_dir=output_dir,
-                source_url=zip(import_ids, source_urls),
+                ids_and_source_urls=zip(import_ids, source_urls),
             )
 
         assert (output_dir / "CCLW.executive.1.1.json").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,10 +70,10 @@ def test_cli_with_source_urls(
                 [
                     "--output-dir",
                     str(output_dir),
-                    "--source-url",
+                    "--id-and-source-url",
                     import_ids[0],
                     source_urls[0],
-                    "--source-url",
+                    "--id-and-source-url",
                     import_ids[1],
                     source_urls[1],
                 ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,6 @@ def test_cli(
 
     # Note: import needed here so that the monkeypatch works, otherwise the
     # environment variables are retrieved before the monkeypatch is applied.
-    from src.cli import cli
 
     with TemporaryDirectory() as temp_dir:
         pdf_dir = Path(temp_dir)
@@ -32,7 +31,9 @@ def test_cli(
         output_dir = Path(temp_dir) / "output"
 
         # patch the azure client with mock
-        with patch("src.cli.AzureApiWrapper", return_value=mock_azure_client):
+        with patch("azure_pdf_parser.AzureApiWrapper", return_value=mock_azure_client):
+            from src.cli import cli
+
             result = runner.invoke(
                 cli, ["--pdf-dir", str(pdf_dir), "--output-dir", str(output_dir)]
             )
@@ -56,7 +57,6 @@ def test_cli_with_source_urls(
 
     # Note: import needed here so that the monkeypatch works, otherwise the
     # environment variables are retrieved before the monkeypatch is applied.
-    from src.cli import cli
 
     with TemporaryDirectory() as temp_dir:
         output_dir = Path(temp_dir) / "output"
@@ -64,7 +64,9 @@ def test_cli_with_source_urls(
         import_ids = ["CCLW.executive.1.1", "CCLW.executive.1.2"]
 
         # patch the azure client with mock
-        with patch("src.cli.AzureApiWrapper", return_value=mock_azure_client):
+        with patch("azure_pdf_parser.AzureApiWrapper", return_value=mock_azure_client):
+            from src.cli import cli
+
             result = runner.invoke(
                 cli,
                 [
@@ -90,8 +92,6 @@ def test_cli_with_source_urls(
 
 
 def test_cli_importable(mock_azure_client, monkeypatch):
-    from src.cli import run_parser
-
     monkeypatch.setenv("AZURE_PROCESSOR_KEY", "hello")
     monkeypatch.setenv("AZURE_PROCESSOR_ENDPOINT", "https://example.com/")
 
@@ -101,7 +101,9 @@ def test_cli_importable(mock_azure_client, monkeypatch):
         import_ids = ["CCLW.executive.1.1", "CCLW.executive.1.2"]
 
         # patch the azure client with mock
-        with patch("src.cli.AzureApiWrapper", return_value=mock_azure_client):
+        with patch("azure_pdf_parser.AzureApiWrapper", return_value=mock_azure_client):
+            from src.cli import run_parser
+
             run_parser(
                 output_dir=output_dir,
                 ids_and_source_urls=zip(import_ids, source_urls),


### PR DESCRIPTION
can be run as a CLI as before, but also now installed and imported:

``` py
from azure_pdf_parser.run import run_parser

run_parser(
    output_dir=Path("./data/processed/oct-23-new-docs"),
    ids_and_source_urls=_ids_and_urls,
)
```

This involved separating the CLI function from its `click` decorators and putting it inside `src/azure_pdf_parser`, and updating the paths of the mocks for the CLIs accordingly.

I also changed the python compatibility to be less restrictive.