### PR TITLE
fix environment loading for CLI, enable raw azure response to be saved

### DIFF
--- a/src/azure_pdf_parser/run.py
+++ b/src/azure_pdf_parser/run.py
@@ -16,6 +16,8 @@ from azure_pdf_parser.convert import azure_api_response_to_parser_output
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
+load_dotenv(find_dotenv())
+
 AZURE_PROCESSOR_KEY = os.environ.get("AZURE_PROCESSOR_KEY")
 AZURE_PROCESSOR_ENDPOINT = os.environ.get("AZURE_PROCESSOR_ENDPOINT")
 
@@ -105,7 +107,6 @@ def run_parser(
     :raises ValueError: if neither source_url or pdf_dir are provided, or if Azure
     API keys are missing from environment variables.
     """
-    load_dotenv(find_dotenv())
 
     if not output_dir.exists():
         LOGGER.warning(f"Output directory {output_dir} does not exist. Creating.")

--- a/src/cli.py
+++ b/src/cli.py
@@ -33,6 +33,12 @@ LOGGER.setLevel(logging.INFO)
     type=click.Path(file_okay=False, path_type=Path),
 )
 @click.option(
+    "--save-raw-azure-response",
+    help="""Whether to save the raw Azure API response to disk. Saved to same directory 
+    as output JSONs with suffix '_raw'.""",
+    is_flag=True,
+)
+@click.option(
     "--experimental-extract-tables",
     help="Whether to extract tables from the PDFs. (WARNING: EXPERIMENTAL)",
     is_flag=True,
@@ -42,10 +48,15 @@ def cli(
     id_and_source_url: Optional[Iterable[tuple[str, str]]],
     pdf_dir: Optional[Path],
     output_dir: Path,
+    save_raw_azure_response: bool,
     experimental_extract_tables: bool,
 ) -> None:
     return run_parser(
-        output_dir, id_and_source_url, pdf_dir, experimental_extract_tables
+        output_dir=output_dir,
+        ids_and_source_urls=id_and_source_url,
+        pdf_dir=pdf_dir,
+        save_raw_azure_response=save_raw_azure_response,
+        experimental_extract_tables=experimental_extract_tables,
     )
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 from typing import Optional, Iterable
 
@@ -9,9 +8,6 @@ from azure_pdf_parser.run import run_parser
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
-
-AZURE_PROCESSOR_KEY = os.environ.get("AZURE_PROCESSOR_KEY")
-AZURE_PROCESSOR_ENDPOINT = os.environ.get("AZURE_PROCESSOR_ENDPOINT")
 
 
 @click.command()


### PR DESCRIPTION
`src/cli.py` wraps `src/run.py`, and environment variables are loaded in `run.py`

changes made:

* `src/cli.py` no longer loads in environment variables as they're not used
* `load_dotenv` is used before setting global variables from environment in `run.py` to ensure they're loaded from a `.env` file if present