### PR TITLE
Bug fix for bad table data

### DIFF
--- a/src/azure_pdf_parser/convert.py
+++ b/src/azure_pdf_parser/convert.py
@@ -207,15 +207,15 @@ def get_all_table_cell_spans(api_response: AnalyzeResult) -> Set[Tuple[int, int]
 
     This is represented as a tuple of (length, offset).
     """
-    if api_response.tables is None:
-        return set()
+    table_cell_spans = set()
 
-    return {
-        (cell.spans[0].length, cell.spans[0].offset)
-        for table in api_response.tables
-        for cell in table.cells
-        if isinstance(cell.spans, list) and len(cell.spans) > 0
-    }
+    if api_response.tables is not None:
+        for table in api_response.tables:
+            for cell in table.cells:
+                if isinstance(cell.spans, list) and len(cell.spans) > 0:
+                    table_cell_spans.add((cell.spans[0].length, cell.spans[0].offset))
+
+    return table_cell_spans
 
 
 def tag_table_paragraphs(api_response: AnalyzeResult) -> AnalyzeResult:

--- a/src/azure_pdf_parser/convert.py
+++ b/src/azure_pdf_parser/convert.py
@@ -214,6 +214,7 @@ def get_all_table_cell_spans(api_response: AnalyzeResult) -> Set[Tuple[int, int]
         (cell.spans[0].length, cell.spans[0].offset)
         for table in api_response.tables
         for cell in table.cells
+        if isinstance(cell.spans, list) and len(cell.spans) > 0
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,7 +305,17 @@ def analyze_result_table_cell_no_spans(one_page_analyse_result) -> AnalyzeResult
             row_index=0,
             row_span=0,
             spans=[],
-        )
+        ),
+        DocumentTableCell(
+            bounding_regions=[],
+            column_index=0,
+            column_span=0,
+            content="",
+            kind="",
+            row_index=0,
+            row_span=0,
+            spans=None,
+        ),
     ]
 
     # Keep only the first table

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,3 +288,30 @@ def analyze_result_known_table_content(
     )
 
     return one_page_analyse_result, paragraphs_with_table_spans, cells, spans
+
+
+@pytest.fixture
+def analyze_result_table_cell_no_spans(one_page_analyse_result) -> AnalyzeResult:
+    """Create an analyze result with a table cell containing no spans."""
+
+    # Create the cells
+    cells = [
+        DocumentTableCell(
+            bounding_regions=[],
+            column_index=0,
+            column_span=0,
+            content="",
+            kind="",
+            row_index=0,
+            row_span=0,
+            spans=[],
+        )
+    ]
+
+    # Keep only the first table
+    one_page_analyse_result.tables = one_page_analyse_result.tables[:1]
+
+    # Replace the table content with the new cells
+    one_page_analyse_result.tables[0].cells = cells
+
+    return one_page_analyse_result

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -224,6 +224,15 @@ def test_tag_table_paragraphs(analyze_result_known_table_content) -> None:
     assert table_paragraph_spans == spans
 
 
+def test_tag_table_paragraphs_bad_data(
+    analyze_result_table_cell_no_spans: AnalyzeResult,
+) -> None:
+    """Test that we can successfully handle bad data in the table."""
+
+    # Tag the table paragraphs
+    tag_table_paragraphs(analyze_result_table_cell_no_spans)
+
+
 def test_table_paragraph_assumptions(
     one_page_analyse_result: AnalyzeResult,
     sixteen_page_analyse_result: AnalyzeResult,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -230,7 +230,16 @@ def test_tag_table_paragraphs_bad_data(
     """Test that we can successfully handle bad data in the table."""
 
     # Tag the table paragraphs
-    tag_table_paragraphs(analyze_result_table_cell_no_spans)
+    analyse_result_tagged = tag_table_paragraphs(analyze_result_table_cell_no_spans)
+
+    # Check the output
+    table_paragraphs = [
+        paragraph
+        for paragraph in analyse_result_tagged.paragraphs
+        if paragraph.role == BlockType.TABLE_CELL.value
+    ]
+
+    assert len(table_paragraphs) == 0
 
 
 def test_table_paragraph_assumptions(


### PR DESCRIPTION
### This Pull Request: 
--- 
- Is a bug fix for a failed test when integrating this version of the azure parser into the main pipeline parser. 
- Fixed by adding failing test the recreated the error in the parser.
- Not entirely sure why the parser tests created this error as the `cells` should always an array of length `1` as per the documentation [here](https://learn.microsoft.com/en-us/python/api/azure-ai-formrecognizer/azure.ai.formrecognizer.analyzeresult?view=azure-python).

![Pasted Graphic 6](https://github.com/climatepolicyradar/azure-pdf-parser/assets/58440325/7679999f-eda3-4857-80c2-4935b08ee8f7)
