### PR TITLE
FIX: Add write permissions to tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,8 @@
 name: Tag Package
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
This Pull Request: 
---
- Adds write permissions to the git repo for the tag workflow. 
- This is as default when the author was dependabot only read access was provisioned and thus the flow failed. 