### PR TITLE
fix detection of PDF type

### DIFF
--- a/src/azure_pdf_parser/convert.py
+++ b/src/azure_pdf_parser/convert.py
@@ -8,7 +8,6 @@ from azure.ai.formrecognizer import (
     Point,
 )
 from cpr_sdk.parser_models import (
-    CONTENT_TYPE_PDF,
     BlockType,
     ParserInput,
     ParserOutput,

--- a/src/azure_pdf_parser/convert.py
+++ b/src/azure_pdf_parser/convert.py
@@ -259,8 +259,11 @@ def azure_api_response_to_parser_output(
         Whether to extract tables from the API response.
     """
 
-    if parser_input.document_content_type != CONTENT_TYPE_PDF:
-        raise ValueError("Document content type must be PDF.")
+    if parser_input.document_cdn_object is None:
+        raise ValueError("Document must have a CDN object. None provided.")
+
+    if parser_input.document_cdn_object is not None and not parser_input.document_cdn_object.lower().endswith(".pdf"):
+        raise ValueError("CDN object must be a PDF.")
 
     api_response = tag_table_paragraphs(api_response)
     text_blocks = extract_azure_api_response_paragraphs(api_response)

--- a/src/azure_pdf_parser/convert.py
+++ b/src/azure_pdf_parser/convert.py
@@ -262,7 +262,10 @@ def azure_api_response_to_parser_output(
     if parser_input.document_cdn_object is None:
         raise ValueError("Document must have a CDN object. None provided.")
 
-    if parser_input.document_cdn_object is not None and not parser_input.document_cdn_object.lower().endswith(".pdf"):
+    if (
+        parser_input.document_cdn_object is not None
+        and not parser_input.document_cdn_object.lower().endswith(".pdf")
+    ):
         raise ValueError("CDN object must be a PDF.")
 
     api_response = tag_table_paragraphs(api_response)

--- a/src/azure_pdf_parser/run.py
+++ b/src/azure_pdf_parser/run.py
@@ -71,7 +71,7 @@ def convert_and_save_api_response(
         document_name="",
         document_description="",
         document_source_url=(AnyHttpUrl(source_url) if source_url else None),
-        document_cdn_object="",
+        document_cdn_object="run-using-cli.pdf",
         document_content_type="application/pdf",
         document_md5_sum="",
         document_slug="",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,7 @@ def parser_input(backend_document_json: dict) -> ParserInput:
         document_slug="slug_123_name",
     )
 
+
 @pytest.fixture
 def parser_input_html(backend_document_json: dict) -> ParserInput:
     """A document which was originally an HTML and has been converted to a PDF"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,8 +185,23 @@ def parser_input(backend_document_json: dict) -> ParserInput:
         document_name="name",
         document_description="description",
         document_source_url=AnyHttpUrl("https://example.com"),
-        document_cdn_object="cdn_object",
+        document_cdn_object="cdn_object.pdf",
         document_content_type="application/pdf",
+        document_md5_sum="md5_sum_123_name",
+        document_slug="slug_123_name",
+    )
+
+@pytest.fixture
+def parser_input_html(backend_document_json: dict) -> ParserInput:
+    """A document which was originally an HTML and has been converted to a PDF"""
+    return ParserInput(
+        document_id="123",
+        document_metadata=BackendDocument.model_validate(backend_document_json),
+        document_name="name",
+        document_description="description",
+        document_source_url=AnyHttpUrl("https://example.com"),
+        document_cdn_object="cdn_object.pdf",
+        document_content_type="text/html",
         document_md5_sum="md5_sum_123_name",
         document_slug="slug_123_name",
     )
@@ -201,7 +216,7 @@ def parser_input_no_content_type(backend_document_json: dict) -> ParserInput:
         document_name="name",
         document_description="description",
         document_source_url=AnyHttpUrl("https://example.com"),
-        document_cdn_object="cdn_object",
+        document_cdn_object=None,
         document_content_type=None,
         document_md5_sum="md5_sum_123_name",
         document_slug="slug_123_name",

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -120,7 +120,7 @@ def test_azure_api_response_to_parser_output(
     assert isinstance(parser_output, ParserOutput)
     assert parser_output.document_md5_sum == md5_sum
     assert parser_output.pdf_data
-    
+
     parser_output_html = azure_api_response_to_parser_output(
         parser_input=parser_input_html,
         md5_sum=md5_sum,
@@ -158,7 +158,6 @@ def test_azure_api_response_to_parser_output(
             md5_sum=md5_sum,
             api_response=one_page_analyse_result,
         )
-
 
     # Test that we can call the vertically_flip_text_block_coords method on the
     # ParserOutput, this will assert that the page numbers are correct as well.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -105,6 +105,7 @@ def test_azure_api_response_to_parser_output(
     parser_input: ParserInput,
     parser_input_no_content_type: ParserInput,
     parser_input_empty_optional_fields: ParserInput,
+    parser_input_html: ParserInput,
     one_page_analyse_result: AnalyzeResult,
 ) -> None:
     """Test that we can convert an azure api response to a parser output object."""
@@ -118,6 +119,16 @@ def test_azure_api_response_to_parser_output(
     )
     assert isinstance(parser_output, ParserOutput)
     assert parser_output.document_md5_sum == md5_sum
+    assert parser_output.pdf_data
+    
+    parser_output_html = azure_api_response_to_parser_output(
+        parser_input=parser_input_html,
+        md5_sum=md5_sum,
+        api_response=one_page_analyse_result,
+    )
+    assert isinstance(parser_output_html, ParserOutput)
+    assert parser_output_html.document_md5_sum == md5_sum
+    assert parser_output_html.pdf_data is not None
 
     # Convert with experimental tables
     parser_output = azure_api_response_to_parser_output(
@@ -147,7 +158,6 @@ def test_azure_api_response_to_parser_output(
             md5_sum=md5_sum,
             api_response=one_page_analyse_result,
         )
-    assert str(context.exception) == "Document content type must be PDF."
 
 
     # Test that we can call the vertically_flip_text_block_coords method on the

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -138,7 +138,7 @@ def test_azure_api_response_to_parser_output(
             md5_sum=md5_sum,
             api_response=one_page_analyse_result,
         )
-    assert str(context.exception) == "Document content type must be PDF."
+    assert str(context.exception) == "Document must have a CDN object. None provided."
 
     # Convert with a parser input object containing empty optional fields
     with unittest.TestCase().assertRaises(ValueError) as context:
@@ -149,16 +149,6 @@ def test_azure_api_response_to_parser_output(
         )
     assert str(context.exception) == "Document content type must be PDF."
 
-    # Convert with a parser input object containing empty optional fields and
-    # experimental tables
-    with unittest.TestCase().assertRaises(ValueError) as context:
-        azure_api_response_to_parser_output(
-            parser_input=parser_input_empty_optional_fields,
-            md5_sum=md5_sum,
-            api_response=one_page_analyse_result,
-            experimental_extract_tables=True,
-        )
-    assert str(context.exception) == "Document content type must be PDF."
 
     # Test that we can call the vertically_flip_text_block_coords method on the
     # ParserOutput, this will assert that the page numbers are correct as well.


### PR DESCRIPTION
Change to checking the extension of the PDF file in the CDN.  Adds a test for a dummy converted HTML file to check that this works.

Resolves stack trace:

```
Traceback (most recent call last):
File \"/app/cli/parse_pdfs.py\", line 577, in run_pdf_parser
    file_parser(input_task=task)
    File \"/app/cli/parse_pdfs.py\", line 430, in parse_file
    document = azure_api_response_to_parser_output(\n  File \"/usr/local/lib/python3.10/site-packages/azure_pdf_parser/convert.py\", line 263, in azure_api_response_to_parser_output
    raise ValueError(\"Document content type must be PDF.\")\nValueError: Document content type must be PDF."
```

This code could do with a facelift, but I've ignored issues here to prioritise fix over refactor. Some things I've noticed:

- no `pre-commit` setup
- CLI (only used for running locally) relies on creating a `ParserInput`, which means making up values of fields that pass validation
- tests could do with some parametrising

Maybe this actually just lives in the main `navigator-document-parser` repo?