### PR TITLE
Remove deprecated reviewers field from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - climatepolicyradar/deng
   - package-ecosystem: github-actions
     commit-message:
       prefix: feat
@@ -26,5 +24,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - climatepolicyradar/deng


### PR DESCRIPTION
The reviewers field in dependabot.yml is being deprecated and will be removed soon. Use CODEOWNERS file instead for specifying reviewers for Dependabot PRs.

Reference: https://github.blog/changelog/2024-02-01-dependabot-will-no-longer-automatically-request-reviews-from-the-reviewers-and-team-reviewers-specified-in-the-dependabot-yml-file/